### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,7 @@ fn main() {
 */
 
 extern crate asynchronous;
-extern crate rustc_serialize;
-
-pub use rustc_serialize as serialize;
+pub extern crate rustc_serialize as serialize;
 
 use asynchronous::{Deferred, Promise};
 use std::collections::BTreeMap;


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#EYIairazTsqVfLa-P5P3BQ/0 and rust-lang/rust#34537 for more details).
Here's a fix.
