### PR TITLE
Fix build on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,7 @@ fn main() {
 */
 
 extern crate asynchronous;
-extern crate rustc_serialize;
-
-pub use rustc_serialize as serialize;
+pub extern crate rustc_serialize as serialize;
 
 use asynchronous::{Deferred, Promise};
 use std::collections::BTreeMap;


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/34537 for more information about the issue).
